### PR TITLE
limits the authorized characters for listname, to avoid command injection

### DIFF
--- a/bureau/admin/mman_doadd.php
+++ b/bureau/admin/mman_doadd.php
@@ -34,6 +34,12 @@ $fields = array (
 );
 getFields($fields);
 
+if (preg_match('/^\w+$/', $login) === 0) {
+	$error=_('Invalid list name (only letters, digits and underscore).');
+	include("mman_add.php");
+	exit();
+}
+
 $r=$mailman->add_lst($domain,$login,$owner,$pass,$pass2);
 if (!$r) {
 	$error=$err->errstr();


### PR DESCRIPTION
This patch prevents user from using characters other than letters, digit and underscore in list names. This should solve https://github.com/AlternC/alternc-mailman/issues/1 and https://github.com/AlternC/alternc-mailman/issues/3.

In the future, same restriction could be applied to password, but eventually, the cron script will have to be fixed.
