### PR TITLE
Fix #11: Add form secret to mailman configuration template

### DIFF
--- a/debian/alternc-mailman.postinst
+++ b/debian/alternc-mailman.postinst
@@ -19,7 +19,7 @@ fi
 case "$1" in
   configure)
     . "$CONFIGFILE"
-
+    . /usr/lib/alternc/functions.sh
     # Then, configure the quota for "mailman"
     /usr/lib/alternc/quota_init mailman 0 
 
@@ -41,7 +41,8 @@ case "$1" in
             exit 1
         fi
     fi
-    sed -e "s/%%fqdn%%/$FQDN/" < "$MAILMAN_CONFIG_TEMPLATE" > "$MAILMAN_CONFIG"
+    SECRET=$(generate_string 32 | sed -e "s/['|&]/\\&/g")
+    sed -e "s/%%fqdn%%/$FQDN/;s|%%mailman_form_secret%%|$SECRET|" < "$MAILMAN_CONFIG_TEMPLATE" > "$MAILMAN_CONFIG"
     cp -a -f "$MAILMAN_CONFIG" "$MAILMAN_CONFIG_BACKUP"
 
     MAILMAN_VERSION=`dpkg -l mailman | grep ^ii | awk '{print $3}' | sed -e s/-.*// -e 's/[^:]*://'`

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -86,4 +86,8 @@ DEFAULT_SERVER_LANGUAGE = 'fr'
 # Alternc-mailman does the job of creating aliases for us.
 MTA = None # So that mailman skips aliases generation
 
+# Once set to a random string, will make Mailman embed a CSRF token into the
+# subscription form and also enforce that the form must be submitted at least
+# five seconds after it was generated. It's a countermeasure in case of
+# subcribtion attack.
 SUBSCRIBE_FORM_SECRET = '%%mailman_form_secret%%'

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -86,3 +86,4 @@ DEFAULT_SERVER_LANGUAGE = 'fr'
 # Alternc-mailman does the job of creating aliases for us.
 MTA = None # So that mailman skips aliases generation
 
+SUBSCRIBE_FORM_SECRET = '%%mailman_form_secret%%'


### PR DESCRIPTION
The form secret is filled in with a random string when dpkg-reconfigure alternc-mailman is run

Refs #11