### PR TITLE
Fix #14: Use a local domain reverse proxy for accessing mailman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install:
 	chown 1999:1999 -R $(DESTDIR)/usr/share/alternc/panel/
 	install -m 0644 mm_cfg.py \
 		$(DESTDIR)/etc/alternc/templates/mailman/
+	install -m 0644 alternc-mailman.conf $(DESTDIR)/etc/alternc/alternc-mailman.conf
 	install -m 0644 -o root -g root src/get_url_alternc.py src/set_url_alternc.py \
 		$(DESTDIR)/usr/lib/mailman/bin/
 	install -m 0755 src/update_mailman.sh \

--- a/alternc-mailman-install
+++ b/alternc-mailman-install
@@ -30,14 +30,15 @@ then
     echo "ensuring apache2 symlink is setup in /etc/apache2/conf.d/"
     # compatibility with both Apache 2.2 and 2.4 makes it Wheezy AND Jessie-compliant : 
     if [ -d "/etc/apache2/conf.d" ]
-	then
-	ln -sf /etc/mailman/apache.conf /etc/apache2/conf.d/mailman.conf 
+    then
+        ln -sf /etc/alternc/alternc-mailman.conf /etc/apache2/conf.d/mailman.conf
     fi
-    if [ -d "/etc/apache2/conf-enabled" ]
-	then
-	ln -sf /etc/mailman/apache.conf /etc/apache2/conf-enabled/mailman.conf 
+    if [ -d "/etc/apache2/conf-available" ]
+    then
+        ln -sf /etc/alternc/alternc-mailman.conf /etc/apache2/conf-enabled/mailman.conf
+        a2enconf mailman.conf
     fi
-fi  
+fi
 
 if [ "$1" = "before-reload" ]
 then

--- a/alternc-mailman-install
+++ b/alternc-mailman-install
@@ -27,15 +27,15 @@ then
     echo "Upgrading AlternC-mailman"
     /usr/share/alternc/install/upgrade_mailman_check.sh
 
-    echo "ensuring apache2 symlink is setup in /etc/apache2/conf.d/"
-    # compatibility with both Apache 2.2 and 2.4 makes it Wheezy AND Jessie-compliant : 
+    echo "Activating configuration in Apache2"
+    # trying to be compliant with Apache2.2 and 2.4 in Wheeze/Jessie/Stretch
     if [ -d "/etc/apache2/conf.d" ]
     then
         ln -sf /etc/alternc/alternc-mailman.conf /etc/apache2/conf.d/mailman.conf
     fi
     if [ -d "/etc/apache2/conf-available" ]
     then
-        ln -sf /etc/alternc/alternc-mailman.conf /etc/apache2/conf-enabled/mailman.conf
+        ln -sf /etc/alternc/alternc-mailman.conf /etc/apache2/conf-available/mailman.conf
         a2enconf mailman.conf
     fi
 fi

--- a/alternc-mailman.conf
+++ b/alternc-mailman.conf
@@ -1,0 +1,60 @@
+#
+# Apache configuration for AlternC-mailman module
+#
+
+Alias /images/mailman/ /usr/share/images/mailman/
+Alias /pipermail/ /var/lib/mailman/archives/public/
+
+<Directory /usr/share/images/mailman/>
+  <IfVersion < 2.4>
+    order allow,deny
+    allow from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all granted
+  </IfVersion>
+</Directory>
+<Directory /var/lib/mailman/archives/public/>
+  order allow,deny
+  allow from all
+  <IfVersion < 2.4>
+    order allow,deny
+    allow from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all granted
+  </IfVersion>
+</Directory>
+
+<VirtualHost *:80>
+  ServerName mailman.localdomain
+  DocumentRoot "/usr/share/alternc-mailman/www"
+  AssignUserId www-data www-data
+
+  ScriptAlias /cgi /usr/lib/cgi-bin/
+
+  <Directory "/usr/share/alternc-mailman/www">
+    php_admin_flag engine off
+    Options +MultiViews -FollowSymLinks
+    AllowOverride none
+  </Directory>
+
+</VirtualHost>
+
+# Global configuration applied to *ALL VHOSTS*
+# This effectively PROXIES every request to mailman
+# to the VirtualHost above,
+# which is using uid/gid of www-data
+# which makes mailman cgi pages happy \o/
+<Proxy *>
+  <IfVersion < 2.4>
+    order allow,deny
+    allow from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all granted
+  </IfVersion>
+</Proxy>
+ProxyRequests Off
+ProxyPreserveHost Off
+ProxyPassReverse /cgi-bin/mailman/ http://mailman.localdomain/cgi/mailman/

--- a/alternc-mailman.conf
+++ b/alternc-mailman.conf
@@ -57,4 +57,4 @@ Alias /pipermail/ /var/lib/mailman/archives/public/
 </Proxy>
 ProxyRequests Off
 ProxyPreserveHost Off
-ProxyPassReverse /cgi-bin/mailman/ http://mailman.localdomain/cgi/mailman/
+ProxyPass /cgi-bin/mailman/ http://mailman.localdomain/cgi/mailman/

--- a/debian/alternc-mailman.postinst
+++ b/debian/alternc-mailman.postinst
@@ -139,6 +139,7 @@ case "$1" in
 
     echo "installing required apache modules" 
     a2enmod rewrite
+    a2enmod proxy
     # only necessary on Jessie: 
     a2enmod cgi || true 
 

--- a/debian/dirs
+++ b/debian/dirs
@@ -12,5 +12,4 @@ usr/share/alternc/panel/class
 usr/share/alternc/panel/locales/en_US/LC_MESSAGES
 usr/share/alternc/panel/locales/fr_FR/LC_MESSAGES
 usr/lib/mailman/bin
-etc/apache2/conf.d
 var/lib/alternc/backups

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -71,7 +71,7 @@ add_virtualhost(DEFAULT_URL_HOST, DEFAULT_EMAIL_HOST)
 
 ACCEPTABLE_LISTNAME_CHARACTERS ='[-+_.= a-z0-9@]'
 DEFAULT_HOST_NAME = '%%fqdn%%'
-DEFAULT_URL_PATTERN = 'http://%s/cgi-bin/mailman/'
+DEFAULT_URL_PATTERN = 'https://%s/cgi-bin/mailman/'
 IMAGE_LOGOS       = '/images/mailman/'
 USE_ENVELOPE_SENDER = 0
 DEFAULT_SEND_REMINDERS = 0
@@ -92,4 +92,6 @@ DEFAULT_SERVER_LANGUAGE = 'fr'
 # Alternc-mailman does the job of creating aliases for us.
 MTA = None # So that mailman skips aliases generation
 
-VIRTUAL_HOST_OVERVIEW = False
+# When set to No, all advertised (i.e. public) lists are included in the
+# overview.
+VIRTUAL_HOST_OVERVIEW = No

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -48,6 +48,12 @@ list-instance-object's dictionary - see the distributed value of
 DEFAULT_MSG_FOOTER for an example."""
 
 
+# This is some trickery to reverse proxies to work with list creation
+# and when restarting mailman.
+import os
+if os.environ.get('REQUEST_URI') is not None:
+    os.environ["REQUEST_URI"] = os.environ["REQUEST_URI"].replace("/cgi/", "/cgi-bin/")
+
 #######################################################
 #    Here's where we get the distributed defaults.    #
 
@@ -86,3 +92,4 @@ DEFAULT_SERVER_LANGUAGE = 'fr'
 # Alternc-mailman does the job of creating aliases for us.
 MTA = None # So that mailman skips aliases generation
 
+VIRTUAL_HOST_OVERVIEW = False

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -99,5 +99,5 @@ VIRTUAL_HOST_OVERVIEW = No
 # Once set to a random string, will make Mailman embed a CSRF token into the
 # subscription form and also enforce that the form must be submitted at least
 # five seconds after it was generated. It's a countermeasure in case of
-# subcription attack.
+# subscription attack.
 SUBSCRIBE_FORM_SECRET = '%%mailman_form_secret%%'

--- a/mm_cfg.py
+++ b/mm_cfg.py
@@ -71,7 +71,7 @@ add_virtualhost(DEFAULT_URL_HOST, DEFAULT_EMAIL_HOST)
 
 ACCEPTABLE_LISTNAME_CHARACTERS ='[-+_.= a-z0-9@]'
 DEFAULT_HOST_NAME = '%%fqdn%%'
-DEFAULT_URL_PATTERN = 'https://%s/cgi-bin/mailman/'
+DEFAULT_URL_PATTERN = 'http://%s/cgi-bin/mailman/'
 IMAGE_LOGOS       = '/images/mailman/'
 USE_ENVELOPE_SENDER = 0
 DEFAULT_SEND_REMINDERS = 0


### PR DESCRIPTION
By default alternc panel runs as a uid which is not accepted by the
debian version of mailman. This takes any requests are proxies it
through mailman.localdomain which runs as the default www-data user.

Refs #14