### PR TITLE
[fix] #100 mettre à jour le url mailman_url dans la db

### DIFF
--- a/src/update_mailman.sh
+++ b/src/update_mailman.sh
@@ -56,7 +56,7 @@ mysql_query "SELECT id,list, name, domain, owner, password FROM mailman WHERE ma
       then
         mysql_query "UPDATE mailman SET mailman_result='A fatal error happened when changing the list url', mailman_action='OK' WHERE id='$id';"
       else
-        mysql_query "UPDATE mailman SET mailman_action='OK' WHERE id='$id';"
+        mysql_query "UPDATE mailman SET mailman_action='SETURL' WHERE id='$id';"
       fi
     fi
   fi
@@ -172,8 +172,9 @@ mysql_query "SELECT id, list, name, domain, url FROM mailman WHERE mailman_actio
     then
     mysql_query "UPDATE mailman SET mailman_result='This list does not exist', mailman_action='OK' WHERE id='$id';"
   else
-# SetURL the list : 
-    	sudo -u list /usr/lib/mailman/bin/withlist -q -l -r set_url_alternc "$name" "$MAILMAN_URL"
+    # SetURL the list :
+    mysql_query "UPDATE mailman SET mailman_result='', mailman_action='OK', url='$MAILMAN_URL' WHERE id='$id';"
+    sudo -u list /usr/lib/mailman/bin/withlist -q -l -r set_url_alternc "$name" "$MAILMAN_URL"
     if [ "$?" -eq "0" ]
       then
       mysql_query "UPDATE mailman SET mailman_result='', mailman_action='OK' WHERE id='$id';"


### PR DESCRIPTION
Lors de la création de la liste dans l'interface web, ça passe ici:
https://github.com/AlternC/alternc-mailman/blob/bee46f6cd22744c2db08f104c89d595d54be3941/bureau/class/m_mailman.php#L248

ça prend la variable globale ici : $L_FQDN
https://github.com/AlternC/alternc-mailman/blob/bee46f6cd22744c2db08f104c89d595d54be3941/bureau/class/m_mailman.php#L249

Le INSERT dans la table mailman se trouve ici, avec comme paramêtre $L_FQDN dans le champs URL
https://github.com/AlternC/alternc-mailman/blob/bee46f6cd22744c2db08f104c89d595d54be3941/bureau/class/m_mailman.php#L307

Donc, on a déjà de rempli le champs url avant la création de la liste dans mailman.  Peut-être qu'on devrait viser directement dans là aller mettre la bonne valeur dans URL, utiliser $MAILMAN_URL à la place de $L_FQDN 

Quand le script update_mailman.sh roule c'est ici que ça boucle dans les listes a créer.
https://github.com/AlternC/alternc-mailman/blob/78176a87ddc8ff2b907f82c5f73878c5d2d670ed/src/update_mailman.sh#L43

Ça fait une configuration du URL seulement dans mailman et non pas dans la db d'alternc, dans  la table mailman...

Mais bon, donc, au lieu de laisser le status de la création à "OK", je le mets à "SETURL" comme ça la boucle plus bas va configurer le URL correctement.

Il reste que dans la boucle plus bas, 
https://github.com/AlternC/alternc-mailman/blob/78176a87ddc8ff2b907f82c5f73878c5d2d670ed/src/update_mailman.sh#L169

Il manque toujours un INSERT pour mettre à jour la db pour le url. C'est ça que j'ai ajouté.

Le code dans le "create list" devrait être modifié parce qu'il duplique en partie la configuration de l'URL... (ça serait un autre PR)

