### PR TITLE
Fixes #29: Show size on disk information for mailman quota

### DIFF
--- a/bureau/class/m_mailman.php
+++ b/bureau/class/m_mailman.php
@@ -626,6 +626,10 @@ class m_mailman {
     if ($db->next_record()) {
       $q['used'] = $db->f("cnt");
     }
+    $db->query("SELECT SUM(size) AS sizeondisk FROM size_mailman WHERE uid = ?", array($cuid));
+    if ($db->next_record()) {
+        $q['sizeondisk'] = $db->f('sizeondisk');
+    }
     return $q;
   }
   


### PR DESCRIPTION
Without this, the size on disk in the quota overview per user will be '-'.