### PR TITLE
copy patch for 2.1.23 to 2.1.29

### DIFF
--- a/patches/mailman-true-virtual-2.1.29.patch
+++ b/patches/mailman-true-virtual-2.1.29.patch
@@ -1,0 +1,139 @@
+--- /usr/lib/mailman/bin/newlist.orig   2012-06-16 20:02:08.000000000 +0200
++++ /usr/lib/mailman/bin/newlist        2014-03-27 19:00:16.527484045 +0100
+@@ -169,7 +169,7 @@
+ 
+     if '@' in listname:
+         # note that --urlhost and --emailhost have precedence
+-        listname, domain = listname.split('@', 1)
++        firstname, domain = listname.split('@', 1)
+         urlhost = urlhost or domain
+         emailhost = emailhost or mm_cfg.VIRTUAL_HOSTS.get(domain, domain)
+ 
+--- /usr/lib/mailman/bin/rmlist.orig    2012-06-16 20:02:08.000000000 +0200
++++ /usr/lib/mailman/bin/rmlist 2014-03-27 18:19:55.025846684 +0100 
+@@ -93,6 +93,11 @@
+         usage(1)
+     listname = args[0].lower().strip()
+ 
++    if '@' in listname:
++        # note that --urlhost and --emailhost have precedence
++        firstname, domain = listname.split('@', 1)
++        listname = '%s-%s' % ( firstname, domain )
++
+     removeArchives = False
+     for opt, arg in opts:
+         if opt in ('-a', '--archives'):
+--- /usr/lib/mailman/Mailman/Gui/General.py.orig        2012-06-16 20:02:08.000000000 +0200
++++ /usr/lib/mailman/Mailman/Gui/General.py     2014-03-27 18:20:09.869854119 +0100  
+@@ -516,7 +516,7 @@
+ 
+     def _setValue(self, mlist, property, val, doc):
+         if property == 'real_name' and \
+-               val.lower() <> mlist.internal_name().lower():
++               val.lower() <> mlist.real_name.lower():
+             # These values can't differ by other than case
+             doc.addError(_("""<b>real_name</b> attribute not
+             changed!  It must differ from the list's name by case
+--- /usr/lib/mailman/Mailman/Handlers/CookHeaders.py.orig	2018-01-09 15:14:47.325723387 +0000
++++ /usr/lib/mailman/Mailman/Handlers/CookHeaders.py	2018-01-09 14:25:24.502725610 +0000
+@@ -295,7 +295,9 @@
+     if msgdata.get('_nolist') or not mlist.include_rfc2369_headers:
+         return
+     # This will act like an email address for purposes of formataddr()
+-    listid = '%s.%s' % (mlist.internal_name(), mlist.host_name)
++    #listid = '%s.%s' % (mlist.internal_name(), mlist.host_name)
++    # internal_name already contains the hostname with the vhost patch
++    listid = mlist.internal_name()
+     cset = Utils.GetCharSet(mlist.preferred_language)
+     if mlist.description:
+         # Don't wrap the header since here we just want to get it properly RFC
+--- /usr/lib/mailman/Mailman/MailList.py.orig	2018-01-09 14:27:26.193139213 +0000
++++ /usr/lib/mailman/Mailman/MailList.py	2018-01-09 14:48:48.869215690 +0000
+@@ -186,9 +186,14 @@
+         return self._full_path
+ 
+     def getListAddress(self, extra=None):
++        posting_addr = self.internal_name()
++        try:
++            posting_addr = self.real_name.lower()
++        except:
++            pass
+         if extra is None:
+-            return '%s@%s' % (self.internal_name(), self.host_name)
+-        return '%s-%s@%s' % (self.internal_name(), extra, self.host_name)
++            return '%s@%s' % (posting_addr, self.host_name)
++        return '%s-%s@%s' % (posting_addr, extra, self.host_name)
+ 
+     # For backwards compatibility
+     def GetBouncesEmail(self):
+@@ -508,11 +513,20 @@
+         # the admin's email address, so transform the exception.
+         if emailhost is None:
+             emailhost = mm_cfg.DEFAULT_EMAIL_HOST
+-        postingaddr = '%s@%s' % (name, emailhost)
++        # default, for when no domain is given
++        firstname = name
++        # we set a special name for virtual hosted lists
++        if '@' in name:
++            firstname, emailhost = name.split('@', 1)
++            name = "%s-%s" % (firstname, emailhost)
++        # but we keep a sensible posting address
++        postingaddr = '%s@%s' % (firstname, emailhost)
+         try:
+             Utils.ValidateEmail(postingaddr)
+         except Errors.EmailAddressError:
+             raise Errors.BadListNameError, postingaddr
++        if Utils.list_exists(name):
++            raise Errors.MMListAlreadyExistsError, name
+         # Validate the admin's email address
+         Utils.ValidateEmail(admin)
+         self._internal_name = name
+@@ -521,6 +535,10 @@
+         self.__lock.lock()
+         self.InitVars(name, admin, crypted_password, urlhost=urlhost)
+         self.CheckValues()
++        # this is for getListAddress
++        self.list_address = postingaddr
++        self.real_name = firstname
++        self.subject_prefix = mm_cfg.DEFAULT_SUBJECT_PREFIX % self.__dict__
+         if langs is None:
+             self.available_languages = [self.preferred_language]
+         else:
+@@ -1435,7 +1453,7 @@
+         addresses in the recipient headers.
+         """
+         # This is the list's full address.
+-        listfullname = '%s@%s' % (self.internal_name(), self.host_name)
++        listfullname = self.getListAddress()
+         recips = []
+         # Check all recipient addresses against the list's explicit addresses,
+         # specifically To: Cc: and Resent-to:
+@@ -1450,7 +1468,7 @@
+             addr = addr.lower()
+             localpart = addr.split('@')[0]
+             if (# TBD: backwards compatibility: deprecated
+-                    localpart == self.internal_name() or
++                    localpart == self.real_name.lower() or
+                     # exact match against the complete list address
+                     addr == listfullname):
+                 return True
+--- /etc/mailman/postfix-to-mailman.py.orig	2018-01-09 15:00:00.188856285 +0000
++++ /etc/mailman/postfix-to-mailman.py	2018-01-09 15:04:16.361629174 +0000
+@@ -120,7 +120,7 @@
+         sys.exit(0)
+ 
+     # Assume normal posting to a mailing list
+-    mlist, func = local, 'post'
++    mlist, func = '%s-%s' % (local, domain), 'post'
+ 
+     # Let Mailman decide if a list exists.
+     from Mailman.Utils import list_exists
+@@ -142,7 +142,7 @@
+                 '-unsubscribe',
+                 ):
+         if local.endswith(ext):
+-            mlist = local[:-len(ext)]
++            mlist = '%s-%s' % (local[:-len(ext)], domain)
+             func  = ext[1:]
+             break
+ 


### PR DESCRIPTION
we currently don't have a patch for mailman's version in debian buster,
2.1.29. I've just tried applying the 2.1.23 patch and it works directly,
so we can just copy it.