### PR TITLE
Fixes #43: Add post_create and pre_delete hooks

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,6 +1,7 @@
 etc/alternc/templates/mailman
 etc/alternc/apache-panel.d/
 usr/lib/alternc/install.d
+usr/lib/alternc/mailman.d
 usr/share/alternc/install
 usr/share/alternc/install/upgrades-mailman
 usr/share/doc/alternc-mailman

--- a/src/update_mailman.sh
+++ b/src/update_mailman.sh
@@ -58,6 +58,7 @@ mysql_query "SELECT id,list, name, domain, owner, password FROM mailman WHERE ma
       else
         mysql_query "UPDATE mailman SET mailman_action='OK' WHERE id='$id';"
       fi
+      run-parts --arg=post_create --arg="$id" /usr/lib/alternc/mailman.d
     fi
   fi
 done
@@ -70,6 +71,7 @@ mysql_query "SELECT id, list, name, domain FROM mailman WHERE mailman_action='DE
     else
 # Delete the list : 
     mysql_query "UPDATE mailman SET mailman_action='DELETING' WHERE id='$id';"
+    run-parts --arg=pre_delete --arg="$id" /usr/lib/alternc/mailman.d
     sudo -u list /usr/lib/mailman/bin/rmlist "$name"
     if [ "$?" -eq "0" ]
       then


### PR DESCRIPTION
This will allow site administrators to modify data when lists are created or
deleted without having to hack the "core" update script shipped by this plugin.